### PR TITLE
Logstash fix for Zipkin traceId propagation

### DIFF
--- a/booking-service/src/main/java/piper1970/bookingservice/service/ReactiveKafkaMessagePostingService.java
+++ b/booking-service/src/main/java/piper1970/bookingservice/service/ReactiveKafkaMessagePostingService.java
@@ -1,7 +1,9 @@
 package piper1970.bookingservice.service;
 
 import static piper1970.eventservice.common.kafka.KafkaHelper.createSenderMono;
+import static piper1970.eventservice.common.kafka.reactive.TracingHelper.extractMDCIntoHeaders;
 
+import brave.Tracer;
 import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,76 +25,93 @@ public class ReactiveKafkaMessagePostingService implements MessagePostingService
 
   private final KafkaSender<Integer, Object> kafkaSender;
   private final Clock clock;
+  private final Tracer tracer;
   private static final String SERVICE_NAME = "booking-service";
 
   @Override
   public Mono<Void> postBookingCreatedMessage(BookingCreated message) {
-    try {
-      var key = message.getBooking().getId();
-      log.debug("Posting BOOKING_CREATED message [{}]", key);
-      return kafkaSender.send(createSenderMono(Topics.BOOKING_CREATED, key, message, clock))
-          .subscribeOn(Schedulers.boundedElastic())
-          .single()
-          .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
-          .then();
-    } catch (Exception e) {
-      log.error("Unknown error occurred while posting BookingCreated message to kafka: {}",
-          e.getMessage(), e);
-      return Mono.error(e);
-    }
+    return Mono.deferContextual(context -> {
+      try {
+        var key = message.getBooking().getId();
+        log.debug("Posting BOOKING_CREATED message [{}]", key);
+        return kafkaSender.send(
+                createSenderMono(Topics.BOOKING_CREATED, key, message, clock,
+                    extractMDCIntoHeaders(tracer)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .single()
+            .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
+            .then();
+      } catch (Exception e) {
+        log.error("Unknown error occurred while posting BookingCreated message to kafka: {}",
+            e.getMessage(), e);
+        return Mono.error(e);
+      }
+    });
   }
 
   @Override
   public Mono<Void> postBookingCancelledMessage(BookingCancelled message) {
-    try {
-      var key = message.getBooking().getId();
-      log.debug("Posting BOOKING_CANCELLED message [{}]", key);
-      return kafkaSender.send(createSenderMono(Topics.BOOKING_CANCELLED, key, message, clock))
-          .subscribeOn(Schedulers.boundedElastic())
-          .single()
-          .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
-          .then();
-    } catch (Exception e) {
-      log.error("Unknown error occurred while posting BookingCancelled message to kafka: {}",
-          e.getMessage(), e);
-      return Mono.error(e);
-    }
+    return Mono.deferContextual(context -> {
+      try {
+        var key = message.getBooking().getId();
+        log.debug("Posting BOOKING_CANCELLED message [{}]", key);
+        return kafkaSender.send(
+                createSenderMono(Topics.BOOKING_CANCELLED, key, message, clock,
+                    extractMDCIntoHeaders(tracer)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .single()
+            .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
+            .then();
+      } catch (Exception e) {
+        log.error("Unknown error occurred while posting BookingCancelled message to kafka: {}",
+            e.getMessage(), e);
+        return Mono.error(e);
+      }
+    });
   }
 
   @Override
   public Mono<Void> postBookingsUpdatedMessage(BookingsUpdated message) {
-    try {
-      var key = message.getEventId();
-      log.debug("Posting BOOKINGS_UPDATED message [{}]", key);
-      return kafkaSender.send(createSenderMono(Topics.BOOKINGS_UPDATED, key, message, clock))
-          .subscribeOn(Schedulers.boundedElastic())
-          .single()
-          .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
-          .then();
-    } catch (Exception e) {
-      log.error("Unknown error occurred while posting BookingsUpdated message to kafka: {}",
-          e.getMessage(), e);
-      return Mono.error(e);
-    }
+    return Mono.deferContextual(context -> {
+      try {
+        var key = message.getEventId();
+        log.debug("Posting BOOKINGS_UPDATED message [{}]", key);
+        return kafkaSender.send(
+                createSenderMono(Topics.BOOKINGS_UPDATED, key, message, clock,
+                    extractMDCIntoHeaders(tracer)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .single()
+            .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
+            .then();
+      } catch (Exception e) {
+        log.error("Unknown error occurred while posting BookingsUpdated message to kafka: {}",
+            e.getMessage(), e);
+        return Mono.error(e);
+      }
+    });
   }
 
   @Override
   public Mono<Void> postBookingsCancelledMessage(BookingsCancelled message) {
-    try {
-      var key = message.getEventId();
-      log.debug("Posting BOOKINGS_CANCELLED message [{}]", key);
-      return kafkaSender.send(createSenderMono(Topics.BOOKINGS_CANCELLED, key, message, clock))
-          .subscribeOn(Schedulers.boundedElastic())
-          .single()
-          .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
-          .doOnError(throwable -> log.error("Error sending BOOKINGS_CANCELLED message: {}",
-              throwable.getMessage(), throwable))
-          .then();
-    } catch (Exception e) {
-      log.error("Unknown error occurred while posting BookingsCancelled message to kafka: {}",
-          e.getMessage(), e);
-      return Mono.error(e);
-    }
+    return Mono.deferContextual(context -> {
+      try {
+        var key = message.getEventId();
+        log.debug("Posting BOOKINGS_CANCELLED message [{}]", key);
+        return kafkaSender.send(
+                createSenderMono(Topics.BOOKINGS_CANCELLED, key, message, clock,
+                    extractMDCIntoHeaders(tracer)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .single()
+            .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
+            .doOnError(throwable -> log.error("Error sending BOOKINGS_CANCELLED message: {}",
+                throwable.getMessage(), throwable))
+            .then();
+      } catch (Exception e) {
+        log.error("Unknown error occurred while posting BookingsCancelled message to kafka: {}",
+            e.getMessage(), e);
+        return Mono.error(e);
+      }
+    });
   }
 
 }

--- a/event-service-common/src/main/java/piper1970/eventservice/common/kafka/KafkaHelper.java
+++ b/event-service-common/src/main/java/piper1970/eventservice/common/kafka/KafkaHelper.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.function.Consumer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
 import org.slf4j.Logger;
 import reactor.core.publisher.Mono;
 import reactor.kafka.sender.SenderRecord;
@@ -22,16 +23,17 @@ public class KafkaHelper {
   }
 
   /**
-   * Wrapper function to send messages through a KafkaSender
+   * Wrapper function to send messages through a KafkaSender.
    *
    * @param topic Topic to send message to
    * @param key Integer key value
    * @param value Message to send
    * @param clock Clock instance to create correlationMetaDataId based off current instance in epoch milliseconds
-   * @return SenderRecord Mon
+   * @param headers Headers to be added to record.
+   * @return SenderRecord Mono
    */
-  public static Mono<SenderRecord<Integer, Object, Long>> createSenderMono(String topic, Integer key, Object value, Clock clock) {
-    var correlationId = Instant.now(clock).toEpochMilli();
-    return Mono.just(SenderRecord.create(new ProducerRecord<>(topic, key, value), correlationId));
+  public static Mono<SenderRecord<Integer, Object, Long>> createSenderMono(String topic, Integer key, Object value, Clock clock, Iterable<Header> headers) {
+    var  correlationId = Instant.now(clock).toEpochMilli();
+    return Mono.just(SenderRecord.create(new ProducerRecord<>(topic, null, key, value, headers), correlationId));
   }
 }

--- a/event-service-common/src/main/java/piper1970/eventservice/common/kafka/reactive/TracingHelper.java
+++ b/event-service-common/src/main/java/piper1970/eventservice/common/kafka/reactive/TracingHelper.java
@@ -1,0 +1,83 @@
+package piper1970.eventservice.common.kafka.reactive;
+
+import brave.Span;
+import brave.Tracer;
+import java.util.ArrayList;
+import java.util.function.Function;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.slf4j.MDC;
+import reactor.core.publisher.Mono;
+import reactor.kafka.receiver.ReceiverRecord;
+
+public class TracingHelper {
+
+  /**
+   * Decorator for kafka message processing that ensures trace/span propagation works for Slf4J logging
+   * @param record Original received kafka record
+   * @param delegate Original message handler
+   * @return Mono of type ReceiverRecord
+   */
+  public static Mono<ReceiverRecord<Integer, Object>> decorateWithTracing(ReceiverRecord<Integer, Object> record,
+      Function<ReceiverRecord<Integer, Object>, Mono<ReceiverRecord<Integer, Object>>> delegate) {
+
+    return Mono.deferContextual(context -> {
+      // restore MDC after call
+      var originalMDC = MDC.getCopyOfContextMap();
+      var headers = record.headers();
+
+      try{
+        var traceIdHeader = headers.lastHeader("X-Trace-Id");
+        var spanIdHeader = headers.lastHeader("X-Span-Id");
+        var b3TraceIdHeader = headers.lastHeader("X-B3-TraceId");
+        var b3SpanIdHeader = headers.lastHeader("X-B3-SpanId");
+
+        // handle traceId propagation, preferring brave's b3-traceid property over standard traceId property
+        if(b3TraceIdHeader != null){
+          MDC.put("traceId", new String(b3TraceIdHeader.value()));
+        }else if(traceIdHeader != null){
+          MDC.put("traceId", new String(traceIdHeader.value()));
+        }
+
+        // handle spanID propagation, preferring brave's b3-spanId property over standard spanId property
+        if(b3SpanIdHeader != null){
+          MDC.put("spanId", new String(b3SpanIdHeader.value()));
+        }else if(spanIdHeader != null){
+          MDC.put("spanId", new String(spanIdHeader.value()));
+        }
+        return delegate.apply(record);
+      }finally {
+        MDC.clear();
+        if(originalMDC != null){ // restore original MDC settings, if present
+          MDC.setContextMap(originalMDC);
+        }
+      }
+    });
+  }
+
+  /**
+   * Extracts traceId & spanId components from brave's Tracer, translating them into Kafka Headers.
+   *
+   * @see Tracer
+   * @return Iterable of Headers, with traceId & spanId headers attached
+   */
+  public static Iterable<Header> extractMDCIntoHeaders(Tracer tracer){
+
+    var headers = new ArrayList<Header>();
+
+    Span currentSpan = tracer.currentSpan();
+    if(currentSpan != null){
+      var context = currentSpan.context();
+      String traceId = context.traceIdString();
+      String spanId = context.spanIdString();
+
+      headers.add(new RecordHeader("X-Trace-Id", traceId.getBytes()));
+      headers.add(new RecordHeader("X-B3-Trace-Id", traceId.getBytes()));
+
+      headers.add(new RecordHeader("X-Span-Id", spanId.getBytes()));
+      headers.add(new RecordHeader("X-B3-Span-Id", spanId.getBytes()));
+    }
+
+    return headers;
+  }
+}

--- a/event-service-common/src/main/java/piper1970/eventservice/common/observations/TracingObservationCustomizer.java
+++ b/event-service-common/src/main/java/piper1970/eventservice/common/observations/TracingObservationCustomizer.java
@@ -20,7 +20,7 @@ public class TracingObservationCustomizer implements
             return !pathMatcher.match("/actuator/**",
                 observationContext.getCarrier().getPath().value());
           } else {
-            return !name.startsWith("spring.security");
+            return !name.startsWith(securityPrefix);
           }
         });
   }

--- a/event-service/src/main/java/piper1970/eventservice/service/ReactiveKafkaMessagePostingService.java
+++ b/event-service/src/main/java/piper1970/eventservice/service/ReactiveKafkaMessagePostingService.java
@@ -1,7 +1,9 @@
 package piper1970.eventservice.service;
 
 import static piper1970.eventservice.common.kafka.KafkaHelper.createSenderMono;
+import static piper1970.eventservice.common.kafka.reactive.TracingHelper.extractMDCIntoHeaders;
 
+import brave.Tracer;
 import java.time.Clock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,60 +20,81 @@ import reactor.kafka.sender.KafkaSender;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class ReactiveKafkaMessagePostingService implements MessagePostingService{
+public class ReactiveKafkaMessagePostingService implements MessagePostingService {
 
   private final KafkaSender<Integer, Object> kafkaSender;
+  private final Tracer tracer;
   private final Clock clock;
   private static final String SERVICE_NAME = "event-service";
 
+
   @Override
   public Mono<Void> postEventCancelledMessage(EventCancelled message) {
-    try{
-      var eventId = message.getEventId();
-      log.debug("Posting EVENT_CANCELLED message [{}]", eventId);
-      return kafkaSender.send(createSenderMono(Topics.EVENT_CANCELLED, eventId, message, clock))
-          .subscribeOn(Schedulers.boundedElastic())
-          .single()
-          .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
-          .doOnError(throwable -> log.error("Error sending EVENT_CANCELLED message: {}", throwable.getMessage(), throwable))
-          .then();
-    }catch(Exception e){
-      log.error("Unknown error occurred while posting EventCancelled message to kafka: {}", e.getMessage(), e);
-      return Mono.error(e);
-    }
+    return Mono.deferContextual(context -> {
+      try {
+        var eventId = message.getEventId();
+
+        log.info("Posting EVENT_CANCELLED message [{}]", eventId);
+        return kafkaSender.send(
+                createSenderMono(Topics.EVENT_CANCELLED, eventId, message, clock, extractMDCIntoHeaders(tracer)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .single()
+            .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
+            .doOnError(throwable -> log.error("Error sending EVENT_CANCELLED message: {}",
+                throwable.getMessage(), throwable))
+            .then();
+      } catch (Exception e) {
+        log.error("Unknown error occurred while posting EventCancelled message to kafka: {}",
+            e.getMessage(), e);
+        return Mono.error(e);
+      }
+    });
+
   }
 
   @Override
   public Mono<Void> postEventChangedMessage(EventChanged message) {
-    try{
-      var eventId = message.getEventId();
-      log.debug("Posting EVENT_CHANGED message [{}]", eventId);
-      return kafkaSender.send(createSenderMono(Topics.EVENT_CHANGED, eventId, message, clock))
-          .subscribeOn(Schedulers.boundedElastic())
-          .single()
-          .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
-          .doOnError(throwable -> log.error("Error sending EVENT_CHANGED message: {}", throwable.getMessage(), throwable))
-          .then();
-    }catch(Exception e){
-      log.error("Unknown error occurred while posting EventChanged message to kafka: {}", e.getMessage(), e);
-      return Mono.error(e);
-    }
+    return Mono.deferContextual(context -> {
+      try {
+        var eventId = message.getEventId();
+        log.debug("Posting EVENT_CHANGED message [{}]", eventId);
+        return kafkaSender.send(
+                createSenderMono(Topics.EVENT_CHANGED, eventId, message, clock, extractMDCIntoHeaders(tracer)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .single()
+            .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
+            .doOnError(throwable -> log.error("Error sending EVENT_CHANGED message: {}",
+                throwable.getMessage(), throwable))
+            .then();
+      } catch (Exception e) {
+        log.error("Unknown error occurred while posting EventChanged message to kafka: {}",
+            e.getMessage(), e);
+        return Mono.error(e);
+      }
+    });
   }
 
   @Override
   public Mono<Void> postEventCompletedMessage(EventCompleted message) {
-    try{
-      var eventId = message.getEventId();
-      log.debug("Posting EVENT_COMPLETED message [{}]", eventId);
-      return kafkaSender.send(createSenderMono(Topics.EVENT_COMPLETED, eventId, message, clock))
-          .subscribeOn(Schedulers.boundedElastic())
-          .single()
-          .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
-          .doOnError(throwable -> log.error("Error sending EVENT_COMPLETED message: {}", throwable.getMessage(), throwable))
-          .then();
-    }catch(Exception e){
-      log.error("Unknown error occurred while posting EventCompleted message to kafka: {}", e.getMessage(), e);
-      return Mono.error(e);
-    }
+    return Mono.deferContextual(context -> {
+      try {
+        var eventId = message.getEventId();
+        log.debug("Posting EVENT_COMPLETED message [{}]", eventId);
+        return kafkaSender.send(
+                createSenderMono(Topics.EVENT_COMPLETED, eventId, message, clock, extractMDCIntoHeaders(tracer)))
+            .subscribeOn(Schedulers.boundedElastic())
+            .single()
+            .doOnNext(KafkaHelper.postReactiveOnNextConsumer(SERVICE_NAME, log))
+            .doOnError(throwable -> log.error("Error sending EVENT_COMPLETED message: {}",
+                throwable.getMessage(), throwable))
+            .then();
+      } catch (Exception e) {
+        log.error("Unknown error occurred while posting EventCompleted message to kafka: {}",
+            e.getMessage(), e);
+        return Mono.error(e);
+      }
+    });
   }
 }
+
+

--- a/event-service/src/test/java/piper1970/eventservice/EventServiceApplicationTests.java
+++ b/event-service/src/test/java/piper1970/eventservice/EventServiceApplicationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import brave.Tracer;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
 import java.time.Clock;
@@ -78,6 +79,9 @@ public class EventServiceApplicationTests {
   @Qualifier("kafka")
   public Retry defaultKafkaRetry;
 
+  @Autowired
+  public Tracer tracer;
+
   //region Properties Used
 
   private final Duration timeoutDuration = Duration.ofSeconds(4);
@@ -116,7 +120,7 @@ public class EventServiceApplicationTests {
         eventRepository, dltProducer, timeoutInMilliseconds, defaultRepositoryRetry));
     discoverableListeners.add(
         new BookingConfirmedListener(receiverFactory, eventRepository,
-            kafkaSender, dltProducer, timeoutInMilliseconds, defaultRepositoryRetry,
+            kafkaSender, tracer, dltProducer, timeoutInMilliseconds, defaultRepositoryRetry,
             defaultKafkaRetry, clock));
 
     discoverableListeners.forEach(DiscoverableListener::initializeReceiverFlux);


### PR DESCRIPTION
Fixed ELK traceId propagation, as well as spanId.

SpanId propagation during kafka publishing and downward is unaligned with Zipkin.

The ELK spanId for the publisher is equivalent to the Zipkin parentId.  This misalignment daisychains downward to the kafka consumers.

Since majority of the issue (#11) has been fixed, both locally and fully-containerized, I've added issue #21 to deal with the spanId misalignment